### PR TITLE
maap-hec-aws#21: updates to propagate K8s job metrics

### DIFF
--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -94,8 +94,11 @@ class ADES_Base:
         #print(ades_resp)
         job_info["status"] = ades_resp["status"]
 
+        # populate current metrics
+        job_info["metrics"] = ades_resp["metrics"]
+
         # and update the db with that status
-        sqlite_update_job_status(job_id, job_info["status"])
+        sqlite_update_job_status(job_id, job_info["status"], job_info["metrics"])
         return job_info
 
     def exec_job(self, proc_id, job_inputs):

--- a/flask_ades_wpst/ades_pbs.py
+++ b/flask_ades_wpst/ades_pbs.py
@@ -205,6 +205,9 @@ echo {{\\"exit_code\\": $?}} > {}
         print("qstat_resp:", qstat_resp)
         job_spec["status"] = \
             self._get_status_from_qstat_stdout(work_dir, qstat_resp.stdout)
+
+        # TODO: populate metrics from PBS; for now return empty metrics
+        job_spec["metrics"] = {}
         
         return job_spec
 

--- a/flask_ades_wpst/sqlite_connector.py
+++ b/flask_ades_wpst/sqlite_connector.py
@@ -57,6 +57,7 @@ def sqlite_db(func):
                                          procID TEXT,
                                          inputs DATA,
                                          backend_info DATA,
+                                         metrics DATA,
                                          status TEXT,
                                          timestamp TEXT
                                        );"""
@@ -167,14 +168,16 @@ def sqlite_exec_job(proc_id, job_id, job_spec, backend_info):
     return sqlite_get_job(job_id)
 
 @sqlite_db
-def sqlite_update_job_status(job_id, status):
+def sqlite_update_job_status(job_id, status, metrics):
     conn = create_connection(db_name)
     cur = conn.cursor()
     sql_str = """UPDATE jobs
                  SET status = \"{}\",
+                     metrics = \'{}\',
                      timestamp = \"{}\"
                  WHERE jobID = \"{}\"""".\
                  format(status,
+                        json.dumps(metrics),
                         datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
                         job_id)
     cur.execute(sql_str)
@@ -183,4 +186,4 @@ def sqlite_update_job_status(job_id, status):
 
 @sqlite_db
 def sqlite_dismiss_job(job_id):
-    return sqlite_update_job_status(job_id, "dismissed")
+    return sqlite_update_job_status(job_id, "dismissed", {})


### PR DESCRIPTION
This PR provides updates to propagate Kubernetes job metrics to the ADES:

- In order to capture the usage report file dumped by calrissian, we update the K8s job submitted to call a wrapper script instead.
  - This wrapper script calls the calrissian executable as before but at the end prints out the contents of the `docker-usage.json` file: https://github.com/pymonger/calrissian/blob/handle-unsupported-file-ops/run_and_dump_usage.sh
  - This records the docker usage stats in the log of the K8s job.
- We then update the ADES_K8s `get_job()` method to extract the metrics from the job's log. The SQLite schema was update to add a new column, `metrics`, which now stores the docker usage stats.