### PR TITLE
maap-hec-aws-83: Update metrics schema in ADES-PBS and support multiple ADES instances

### DIFF
--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -103,6 +103,7 @@ class ADES_Base:
         # dismissed, successful, or failed
         job_info = {
             "jobID": job_id,
+            "job_type": proc_id,
             "username": job_spec["jobOwner"],
             "time_queued": job_spec["timeCreated"],
             "status": job_spec["status"],

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -104,6 +104,7 @@ class ADES_Base:
         job_info = {
             "jobID": job_id,
             "username": job_spec["jobOwner"],
+            "time_queued": job_spec["timeCreated"],
             "status": job_spec["status"],
             "metrics": job_spec["metrics"]
         }

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -113,7 +113,6 @@ class ADES_Base:
 
         # otherwise, query the ADES backend for the current status
         ades_resp = self._ades.get_job(job_spec)
-        # print(ades_resp)
         job_info["status"] = ades_resp["status"]
 
         # populate current metrics

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -28,8 +28,7 @@ class ADES_Base:
         self._ades_id = app_config["ADES_ID"]
         self._ades = ADES_Platform(self._ades_id)
         ades_home_dir = os.path.join("./ades", self._ades_id)
-        if not os.path.isdir(ades_home_dir):
-            os.mkdir(ades_home_dir)
+        os.makedirs(ades_home_dir, exist_ok=True)
         sqlite_db_dir = os.path.join(ades_home_dir, "sqlite")
         if not os.path.isdir(sqlite_db_dir):
             os.mkdir(sqlite_db_dir)

--- a/flask_ades_wpst/ades_base.py
+++ b/flask_ades_wpst/ades_base.py
@@ -33,6 +33,7 @@ class ADES_Base:
             # flask_wpst.py.
             raise ValueError("Platform {} not implemented.".format(self._platform))
         self._ades = ADES_Platform()
+        self._ades_id = app_config["ADES_ID"]
 
     def proc_dict(self, proc):
         return {

--- a/flask_ades_wpst/ades_pbs.py
+++ b/flask_ades_wpst/ades_pbs.py
@@ -8,8 +8,9 @@ from pprint import pprint
 
 class ADES_PBS(ADES_ABC):
 
-    def __init__(self, base_work_dir='./jobs', job_inputs_fname='inputs.yml',
-                 sing_stash_dir='./singularity', module_cmd='modulecmd',
+    def __init__(self, ades_id, 
+                 base_ades_home_dir='./ades', base_work_dir='./jobs',
+                 job_inputs_fname='inputs.yml', sing_stash_dir='./singularity', module_cmd='modulecmd',
                  singularity_cmd='./bin/singularity', pbs_qsub_cmd='./bin/qsub',
                  pbs_qdel_cmd='./bin/qdel', pbs_qstat_cmd='./bin/qstat',
                  pbs_script_fname='pbs.bash',
@@ -33,9 +34,21 @@ cwl-runner --singularity --no-match-user --no-read-only --tmpdir-prefix {} --lea
 echo {{\\"exit_code\\": $?}} > {}
 python -m flask_ades_wpst.get_pbs_metrics -l {} -m {} -e {}
 """):
-        self._base_work_dir = base_work_dir
+        self._ades_id = ades_id
+        self._ades_home_dir = os.path.join(base_ades_home_dir,
+                                           self._ades_id)
+        if not os.path.isdir(self._ades_home_dir):
+            os.mkdir(self._ades_home_dir)
+            print("mkdir:", self._ades_home_dir)
+        self._base_work_dir = os.path.join(self._ades_home_dir,
+                                           base_work_dir)
+        if not os.path.isdir(self._base_work_dir):
+            os.mkdir(self._base_work_dir)
         self._job_inputs_fname = job_inputs_fname
-        self._sing_stash_dir = sing_stash_dir
+        self._sing_stash_dir = os.path.join(self._ades_home_dir,
+                                            sing_stash_dir)
+        if not os.path.isdir(self._sing_stash_dir):
+            os.mkdir(self._sing_stash_dir)
         self._pbs_script_fname = pbs_script_fname
         self._module_cmd = module_cmd
         self._singularity_cmd = singularity_cmd

--- a/flask_ades_wpst/ades_pbs.py
+++ b/flask_ades_wpst/ades_pbs.py
@@ -10,7 +10,7 @@ class ADES_PBS(ADES_ABC):
 
     def __init__(self, ades_id, 
                  base_ades_home_dir='./ades', base_work_dir='./jobs',
-                 job_inputs_fname='inputs.yml',
+                 job_inputs_fname='inputs.json',
                  sing_stash_dir='./singularity', module_cmd='modulecmd',
                  singularity_cmd='./bin/singularity',
                  pbs_qsub_cmd='./bin/qsub', pbs_qdel_cmd='./bin/qdel',
@@ -154,7 +154,7 @@ python -m flask_ades_wpst.get_pbs_metrics -l {} -m {} -e {}
         except:
             raise OSError("Could not create work directory {} for job {}".format(work_dir, job_id))
 
-        # Write job inputs YAML to a file in the work directory.
+        # Write job inputs to a JSON file in the work directory.
         job_inputs_fname = os.path.join(work_dir, self._job_inputs_fname)
         with open(job_inputs_fname, 'w', encoding='utf-8') as job_inputs_file:
             json.dump(job_spec['inputs'], job_inputs_file, ensure_ascii=False,

--- a/flask_ades_wpst/ades_pbs.py
+++ b/flask_ades_wpst/ades_pbs.py
@@ -10,14 +10,14 @@ class ADES_PBS(ADES_ABC):
 
     def __init__(self, ades_id, 
                  base_ades_home_dir='./ades', base_work_dir='./jobs',
-                 job_inputs_fname='inputs.yml', sing_stash_dir='./singularity', module_cmd='modulecmd',
-                 singularity_cmd='./bin/singularity', pbs_qsub_cmd='./bin/qsub',
-                 pbs_qdel_cmd='./bin/qdel', pbs_qstat_cmd='./bin/qstat',
-                 pbs_script_fname='pbs.bash',
-                 exit_code_fname = "exit_code.json", 
-                 cwl_runner_log_fname = "cwl_runner.log",
-                 metrics_fname = "metrics.json",
-                 pbs_script_stub = """#!/bin/bash
+                 job_inputs_fname='inputs.yml',
+                 sing_stash_dir='./singularity', module_cmd='modulecmd',
+                 singularity_cmd='./bin/singularity',
+                 pbs_qsub_cmd='./bin/qsub', pbs_qdel_cmd='./bin/qdel',
+                 pbs_qstat_cmd='./bin/qstat', pbs_script_fname='pbs.bash',
+                 exit_code_fname="exit_code.json",
+                 cwl_runner_log_fname="cwl_runner.log",
+                 metrics_fname="metrics.json", pbs_script_stub="""#!/bin/bash
 #
 #PBS -q long
 #PBS -lselect=1:ncpus=1:model=bro

--- a/flask_ades_wpst/ades_pbs.py
+++ b/flask_ades_wpst/ades_pbs.py
@@ -31,7 +31,7 @@ cd {}
 # Run workflow
 cwl-runner --singularity --no-match-user --no-read-only --tmpdir-prefix {} --leave-tmpdir --timestamps {} {} > {} 2>&1
 echo {{\\"exit_code\\": $?}} > {}
-python -m flask_ades_wpst.get_pbs_metrics -l {} -m {} -e {} -p {}
+python -m flask_ades_wpst.get_pbs_metrics -l {} -m {} -e {}
 """):
         self._base_work_dir = base_work_dir
         self._job_inputs_fname = job_inputs_fname
@@ -163,8 +163,7 @@ python -m flask_ades_wpst.get_pbs_metrics -l {} -m {} -e {} -p {}
                                          self._exit_code_fname,
                                          self._cwl_runner_log_fname,
                                          self._metrics_fname,
-                                         self._exit_code_fname,
-                                         self._pbs_script_fname))
+                                         self._exit_code_fname))
 
         # Submit job to queue for execution.
         qsub_resp = run([self._pbs_qsub_cmd, "-N", job_id, "-o", work_dir, 

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -8,6 +8,24 @@ from socket import getfqdn
 from datetime import datetime
 
 
+##############################################################################
+# Set the version of the JSON response API used.  This version number will
+# automatically be included as part of every JSON response.  Client codes
+# can check this version to determine what keywords and structure are
+# expected from each WPS-T endpoint.
+#
+# Recommended process for updating this API version:
+# Update this API version setting everytime the JSON structure of any
+# endpoint response is changed.  If this is in a development branch in
+# between public releases, modify the part to the right of the decimal
+# point.  In preparing for a new release, if the part to the right of the
+# decimal point is "0" (meaning no change in API since the last release),
+# then leave this  unchanged.  If the part to the right of the decimal point
+# is not "0", then increment the part to the left of the decimal point and set
+# the part to the right of the decimal point to "0".
+API_VERSION = "1.0"
+##############################################################################
+
 app = Flask(__name__)
 
 def default_ades_id():
@@ -33,8 +51,9 @@ def parse_args():
 def ades_resp(d):
     '''Inject additional elements into every endpoint response.
     '''
-    # Add ADES ID to the Flask endpoint return dictionary.
-    d |= { "ades_id": app.config["ADES_ID"] }
+    # Add additional global elements to the Flask endpoint return dictionary.
+    d |= { "ades_id": app.config["ADES_ID"],
+           "api_version": API_VERSION }
     return d
 
 @app.route("/", methods = ['GET'])

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -8,8 +8,10 @@ def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-H", "--host", default="127.0.0.1",
                         help="host IP address for Flask server")
+    parser.add_argument("-p", "--port", default=5000,
+                        help="host port number for Flask server")
     args = parser.parse_args()
-    return args.host
+    return args.host, args.port
 
 app = Flask(__name__)
 
@@ -99,17 +101,17 @@ def processes_result(procID, jobID):
     resp_dict = ades_base.get_job_results(procID, jobID)
     return resp_dict, status_code, {'ContentType':'application/json'}
 
-def flask_wpst(app, debug=False, host="127.0.0.1",
+def flask_wpst(app, debug=False, host="127.0.0.1", port=5000,
                valid_platforms = ("Generic", "K8s", "PBS")):
     platform = os.environ.get("ADES_PLATFORM", default="Generic")
     if platform not in valid_platforms:
         raise ValueError("ADES_PLATFORM invalid - {} not in {}.".\
                          format(platform, valid_platforms))
     app.config["PLATFORM"] = platform
-    app.run(debug=debug, host=host)
+    app.run(debug=debug, host=host, port=port)
     
 
 if __name__ == "__main__":
     print ("starting")
-    host = parse_args()
-    flask_wpst(app, debug=True, host=host)
+    host, port = parse_args()
+    flask_wpst(app, debug=True, host=host, port=port)

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -100,7 +100,8 @@ def processes_jobs(procID):
     elif request.method == 'POST':
         status_code = 201
         job_params = request.get_json()
-        job_info = ades_base.exec_job(procID, job_params)
+        req_vals = request.values
+        job_info = ades_base.exec_job(procID, job_params, req_vals)
         resp_dict = job_info
     return (ades_resp(resp_dict), 
             status_code, {'ContentType':'application/json'})

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -38,7 +38,8 @@ def default_ades_id():
 
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("-d", "--debug", action="store_true")
+    parser.add_argument("-d", "--debug", action="store_true",
+                        help="turn on Flask debug mode")
     parser.add_argument("-H", "--host", default="127.0.0.1",
                         help="host IP address for Flask server")
     parser.add_argument("-p", "--port", default=5000,

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -34,7 +34,7 @@ def ades_resp(d):
     '''Inject additional elements into every endpoint response.
     '''
     # Add ADES ID to the Flask endpoint return dictionary.
-    d |= { "ades-id": app.config["ADES_ID"] }
+    d |= { "ades_id": app.config["ADES_ID"] }
     return d
 
 @app.route("/", methods = ['GET'])

--- a/flask_ades_wpst/flask_wpst.py
+++ b/flask_ades_wpst/flask_wpst.py
@@ -20,6 +20,7 @@ def default_ades_id():
 
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("-d", "--debug", action="store_true")
     parser.add_argument("-H", "--host", default="127.0.0.1",
                         help="host IP address for Flask server")
     parser.add_argument("-p", "--port", default=5000,
@@ -27,7 +28,7 @@ def parse_args():
     parser.add_argument("-n", "--name", 
                         help="ID of this ADES instance")
     args = parser.parse_args()
-    return args.host, args.port, args.name
+    return args.debug, args.host, args.port, args.name
 
 def ades_resp(d):
     '''Inject additional elements into every endpoint response.
@@ -140,8 +141,8 @@ def flask_wpst(app, debug=False, host="127.0.0.1", port=5000,
 
 if __name__ == "__main__":
     print ("starting")
-    flask_host, flask_port, ades_id = parse_args()
+    debug_mode, flask_host, flask_port, ades_id = parse_args()
     if ades_id is None:
         ades_id = default_ades_id()
     app.config["ADES_ID"] = ades_id
-    flask_wpst(app, debug=True, host=flask_host, port=flask_port)
+    flask_wpst(app, debug=debug_mode, host=flask_host, port=flask_port)

--- a/flask_ades_wpst/get_pbs_metrics.py
+++ b/flask_ades_wpst/get_pbs_metrics.py
@@ -1,12 +1,11 @@
 import argparse
 import os
 import re
-from datetime import datetime, timezone
-from pprint import pprint
-import socket
-import shutil
 import json
-import psutil
+from datetime import datetime, timezone
+from socket import getfqdn, gethostbyname
+from shutil import disk_usage
+from psutil import virtual_memory
 
 def parse_args():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
@@ -14,14 +13,12 @@ def parse_args():
                         help="input log file")
     parser.add_argument("-e", "--exitcode", required=True,
                         help="input exit_code.json file")
-    parser.add_argument("-p", "--pbs", required=True,
-                        help="input pbs.bash script")
     parser.add_argument("-m", "--metrics", required=True,
                         help="output metrics.json file")
     args = parser.parse_args()
-    return args.log, args.exitcode, args.pbs, args.metrics
+    return args.log, args.exitcode, args.metrics
 
-def get_disk_mb(start_dir, excludes=[]):
+def get_disk_gb(start_dir, excludes=[]):
     disk_bytes = 0
     for path, dirs, files in os.walk(start_dir):
         for f in files:
@@ -30,21 +27,21 @@ def get_disk_mb(start_dir, excludes=[]):
                         for ex in excludes]):
                 cur_bytes = os.path.getsize(fpath)
                 disk_bytes += os.path.getsize(fpath)
-    return disk_bytes / 1048576 # convert bytes to MB
+    return disk_bytes / 1073741824 # convert bytes to GB
 
 def step_disk_usage(step_name):
-    if step_name == "stage_in":
+    if step_name.startswith("stage-in"):
         # all storage for stage in step is assumed to be in the inputs
         # subdirectory.
-        disk_mb = get_disk_mb("inputs")
-    elif step_name == "stage_out":
+        disk_gb = get_disk_gb("inputs")
+    elif step_name.startswith("stage-out"):
         # stage out step is assumed to use no storage.
-        disk_mb = 0
+        disk_gb = 0
     else:
         # process step:  Add up size of the entire work directory, but 
         # excluding everything under the inputs subdirectory.
-        disk_mb = get_disk_mb(".", excludes=["inputs"])
-    return disk_mb
+        disk_gb = get_disk_gb(".", excludes=["inputs"])
+    return disk_gb
 
 def reformat_dt(dt_str_src, dt_fmt_src, dt_fmt_dst):
     dt_src = datetime.strptime(dt_str_src, dt_fmt_src)
@@ -52,20 +49,21 @@ def reformat_dt(dt_str_src, dt_fmt_src, dt_fmt_dst):
     dt_str_dst = dt_src_utc.strftime(dt_fmt_dst)
     return dt_str_dst
 
-def get_step_times_from_log(log_fname):
+def get_step_info_from_log(log_fname):
     dt_fmt_src = "%Y-%m-%d %H:%M:%S"
     dt_fmt_dst = "%Y-%m-%dT%H:%M:%S%z"
     pattern_start = re.compile("\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\].+\[step\s(.+)\]\sstart")
-    pattern_end = re.compile("\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\].+\[step\s(.+)\]\scompleted")
+    pattern_end = re.compile("\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\].+\[step\s(.+)\]\scompleted\s+(\w+)")
     
     with open(log_fname, 'r') as f:
         step_starts = []
         step_ends = []
         step_names = []
+        step_status = []
         for line in f:
             match_start = pattern_start.search(line)
             if match_start is not None:
-                print("START", line)
+                # START of job step
                 start_time = reformat_dt(match_start.group(1),
                                          dt_fmt_src, dt_fmt_dst)
                 step_starts.append(start_time)
@@ -73,108 +71,89 @@ def get_step_times_from_log(log_fname):
             else:
                 match_end = pattern_end.search(line)
                 if match_end is not None:
-                    print("END", line)
+                    # END of job step
                     end_time = reformat_dt(match_end.group(1),
                                            dt_fmt_src, dt_fmt_dst)
                     step_ends.append(end_time)
-    return list(zip(step_names, step_starts, step_ends))
+                    step_status.append(match_end.group(3))
+    return list(zip(step_names, step_starts, step_ends, step_status))
 
-def step_duration_seconds(start_time_str, end_time_str):
+def duration_secs(start_time_str, end_time_str):
     dt_fmt = "%Y-%m-%dT%H:%M:%S%z"
     start_time = datetime.strptime(start_time_str, dt_fmt)
     end_time = datetime.strptime(end_time_str, dt_fmt)
     return end_time.timestamp() - start_time.timestamp()
 
-def get_usage_stats(log_fname):
-    step_times = get_step_times_from_log(log_fname)
-    print(step_times)
-    usage_stats = {"children": 
-                   [{"name": step_time[0],
-                     "start_time": step_time[1],
-                     "finish_time": step_time[2],
-                     "cpus": 1.0,
-                     "ram_megabytes": -999.,
-                     "ram_megabytes_hours": -999.,
-                     "disk_megabytes": step_disk_usage(step_time[0])} 
-                    for step_time in step_times]}
-    for step_usage_stats in usage_stats["children"]:
-        step_usage_stats["elapsed_seconds"] = \
-            step_duration_seconds(step_usage_stats["start_time"], 
-                                  step_usage_stats["finish_time"])
-        step_usage_stats["elapsed_hours"] = \
-            step_usage_stats["elapsed_seconds"] / 3600
-        step_usage_stats["cpu_hours"] = \
-            step_usage_stats["elapsed_hours"] * step_usage_stats["cpus"]
-    usage_stats |= {"cores_allowed": 1.,
-                    "finish_time": usage_stats["children"][-1]["finish_time"],
-                    "max_parallel_cpus": 1.,
-                    "max_parallel_ram_megabytes": -999.,
-                    "max_parallel_tasks": 1,
-                    "ram_mb_allowed": -999.,
-                    "start_time": usage_stats["children"][0]["start_time"],
-                    "total_cpu_hours": \
-                    sum([ch["cpu_hours"] for ch in usage_stats["children"]]),
-                    "total_disk_megabytes": \
-                    sum([ch["disk_megabytes"]
-                         for ch in usage_stats["children"]]),
-                    "total_ram_megabyte_hours": -999.,
-                    "total_tasks": len(usage_stats["children"])}
-    usage_stats |= {"elapsed_seconds": \
-                    step_duration_seconds(usage_stats["start_time"],
-                                          usage_stats["finish_time"])}
-    usage_stats |= {"elapsed_hours": usage_stats["elapsed_seconds"] / 3600}
-    return usage_stats
+def get_node_info():
+    hostname = getfqdn()
+    ip_addr = gethostbyname(hostname)
+    memory_avail_bytes = virtual_memory().total
+    disk_space_free_bytes = disk_usage('.').free
+    bytes_per_gb = 1073741824
+    return { "node_type": "broadwell",
+             "cores": 1,
+             "memory_gb": memory_avail_bytes / bytes_per_gb,
+             "hostname": hostname,
+             "ip_address": ip_addr,
+             "disk_space_free_gb": disk_space_free_bytes / bytes_per_gb }
 
-def get_process_stats(usage_stats):
-    hostname = socket.getfqdn()
-    ip_addr = socket.gethostbyname(hostname)
-    disk_space_free_bytes = shutil.disk_usage('.').free
-    process_stats = [{
-        "name": child["name"],
-        "time_started": child["start_time"],
-        "time_end": child["finish_time"],
-        "work_dir_size_gb": child["disk_megabytes"] / 1024,
-        "memory_max_gb": -999.,
-        "node": {
-            "cores": child["cpus"],
-            "memory_gb": psutil.virtual_memory().total / 1073741824, # GB
-            "hostname": hostname,
-            "ip_address": ip_addr,
-            "disk_space_free_gb": disk_space_free_bytes / 1073741824 # GB
-        }} for child in usage_stats["children"]]
-    return process_stats
+def get_workflow_metrics():
+    metrics_steps = { workflow_step[0]: workflow_step[1]
+                      for workflow_step in workflow_info }
 
-def get_workflow_stats(usage_stats, exit_code_fname, pbs_bash_fname):
-    # The PBS bash script creation time is a good approximation of the 
-    # time the job was queued, because those events both happened in the 
-    # execute job call.
-    dt_fmt = "%Y-%m-%dT%H:%M:%S%z"
-    queue_ts = os.path.getctime(pbs_bash_fname)
-    print("timestamp", pbs_bash_fname, queue_ts)
-    queue_dt = datetime.fromtimestamp(queue_ts).astimezone(tz=timezone.utc)
-    queue_dt_str = queue_dt.strftime(dt_fmt)
-
+def get_exit_code(exit_code_fname):
     # Load exit_code from JSON file.
     with open(exit_code_fname, 'r') as f:
         d = json.loads(f.read())
         exit_code = d["exit_code"]
-    
-    # Populate workflow stats.
-    workflow_stats = {"exit_code": exit_code,
-                      "time_queued": queue_dt_str,
-                      "time_started": usage_stats["children"][0]["start_time"],
-                      "time_end": usage_stats["children"][0]["finish_time"] }
-    return workflow_stats
+    return exit_code
 
 def get_pbs_metrics():
-    log_fname, exit_code_fname, pbs_bash_fname, metrics_fname = parse_args()
-    usage_stats = get_usage_stats(log_fname)
-    process_stats = get_process_stats(usage_stats)
-    workflow_stats = get_workflow_stats(usage_stats, exit_code_fname,
-                                        pbs_bash_fname)
-    metrics = { "blob": usage_stats,
-                "processes": process_stats,
-                "workflow": workflow_stats }
+    # Parse input arguments
+    log_fname, exit_code_fname, metrics_fname = parse_args()
+
+    # Get information about the compute node used for the job execution.
+    # For ADES_PBS, all the workflow steps run on the same node, so this 
+    # information applies to the entire workflow.
+    node_info = get_node_info()
+
+    # Get exit code for the job, indicating if the job succeeded or failed.
+    # For ADES_PBS, for now we are not capturing the exit code for each
+    # step, so we assign each step the exit code of the overall workflow.
+    exit_code = get_exit_code(exit_code_fname)
+
+    # Get a list of tuples giving step name, start time (UTC), and end time 
+    # (UTC) for each step of the job's workflow.
+    job_steps = get_step_info_from_log(log_fname)
+
+    # Construct metrics dictionary.
+    metrics = { job_step[0] : 
+                { "time_start" : job_step[1],
+                  "time_end" : job_step[2],
+                  "time_duration_seconds" : duration_secs(job_step[1],
+                                                          job_step[2]),
+                  "work_dir_size_gb": step_disk_usage(job_step[1]),
+                  "memory_max_gb": -999.,
+                  "exit_code": int(job_step[3] != "success"),
+                  "node": node_info }
+                for job_step in job_steps }
+
+    # Add in workflow level metrics for the entire multi-step job.
+    workflow_start = job_steps[0][1] # 1st start time
+    workflow_end =  job_steps[-1][2] # last end time
+    workflow_dir_size_gb = sum([metrics[d]["work_dir_size_gb"]
+                                for d in metrics])
+    workflow_metrics = { "time_start": workflow_start,
+                         "time_end": workflow_end,
+                         "time_duration_seconds": duration_secs(workflow_start,
+                                                                workflow_end),
+                         "work_dir_size_gb": workflow_dir_size_gb,
+                         "memory_max_gb": -999.,
+                         "exit_code": exit_code,
+                         "node": node_info }
+    metrics |= { "workflow": workflow_metrics }
+
+    # Save metrics to work directory.
     with open(metrics_fname, 'w') as f:
         f.write(json.dumps(metrics, indent=4))
     print("Metrics written to {}".format(metrics_fname))

--- a/flask_ades_wpst/sqlite_connector.py
+++ b/flask_ades_wpst/sqlite_connector.py
@@ -5,241 +5,235 @@ import requests
 import yaml
 from datetime import datetime
 
-db_name = "./sqlite/soamc_ades.db"
 
+class SQLiteConnector():
 
-def create_connection(db_file):
-    """ create a database connection to the SQLite database
-        specified by db_file
-    :param db_file: database file
-    :return: Connection object or None
-    """
-    conn = None
-    try:
-        conn = sqlite3.connect(db_file)
+    def __init__(self, db_name="./sqlite/sqlite.db"):
+        self._db_name = db_name
+
+    def _create_connection(self, db_file):
+        """ create a database connection to the SQLite database
+            specified by db_file
+        :param db_file: database file
+        :return: Connection object or None
+        """
+        conn = None
+        try:
+            conn = sqlite3.connect(db_file)
+            return conn
+        except sqlite3.Error as e:
+            print(e)
         return conn
-    except sqlite3.Error as e:
-        print(e)
-    return conn
 
+    def _create_table(self, conn, create_table_sql):
+        """ create a table from the create_table_sql statement
+        :param conn: Connection object
+        :param create_table_sql: a CREATE TABLE statement
+        :return:
+        """
+        try:
+            c = conn.cursor()
+            c.execute(create_table_sql)
+        except Error as e:
+            print(e)
 
-def create_table(conn, create_table_sql):
-    """ create a table from the create_table_sql statement
-    :param conn: Connection object
-    :param create_table_sql: a CREATE TABLE statement
-    :return:
-    """
-    try:
-        c = conn.cursor()
-        c.execute(create_table_sql)
-    except Error as e:
-        print(e)
+    def _sqlite_get_headers(self, cur, tname):
+        sql_str = 'SELECT name FROM PRAGMA_TABLE_INFO("{}");'.format(tname)
+        cur.execute(sql_str)
+        col_headers = [t[0] for t in cur.fetchall()]
+        return col_headers
 
+    def sqlite_db(func):
+        from functools import wraps
+        @wraps(func)
+        def wrapper_sqlite_db(self, *args, **kwargs):
+            init_table = not os.path.exists(self._db_name)
+            conn = self._create_connection(self._db_name)
+            if conn is None:
+                raise ValueError("Could not create the database connection.")
+            if init_table:
+                sql_create_procs_table = """CREATE TABLE IF NOT EXISTS processes (
+                                              id TEXT PRIMARY KEY,
+                                              title TEXT,
+                                              abstract TEXT,
+                                              keywords TEXT,
+                                              owsContextURL TEXT,
+                                              processVersion TEXT,
+                                              jobControlOptions TEXT,
+                                              outputTransmission TEXT,
+                                              immediateDeployment INTEGER,
+                                              executionUnit TEXT
+                                            );"""
+                sql_create_jobs_table = """CREATE TABLE IF NOT EXISTS jobs (
+                                             jobID TEXT PRIMARY KEY,
+                                             procID TEXT,
+                                             inputs DATA,
+                                             backend_info DATA,
+                                             metrics DATA,
+                                             status TEXT,
+                                             timestamp TEXT
+                                           );"""
+                self._create_table(conn, sql_create_procs_table)
+                self._create_table(conn, sql_create_jobs_table)
+            return func(self, *args, **kwargs)
+        return wrapper_sqlite_db
 
-def sqlite_db(func):
-    def wrapper_sqlite_db(*args, **kwargs):
-        init_table = not os.path.exists(db_name)
-        conn = create_connection(db_name)
-        if conn is None:
-            raise ValueError("Could not create the database connection.")
-        if init_table:
-            sql_create_procs_table = """CREATE TABLE IF NOT EXISTS processes (
-                                          id TEXT PRIMARY KEY,
-                                          title TEXT,
-                                          abstract TEXT,
-                                          keywords TEXT,
-                                          owsContextURL TEXT,
-                                          processVersion TEXT,
-                                          jobControlOptions TEXT,
-                                          outputTransmission TEXT,
-                                          immediateDeployment INTEGER,
-                                          executionUnit TEXT
-                                        );"""
-            sql_create_jobs_table = """CREATE TABLE IF NOT EXISTS jobs (
-                                         jobID TEXT PRIMARY KEY,
-                                         procID TEXT,
-                                         inputs DATA,
-                                         backend_info DATA,
-                                         metrics DATA,
-                                         status TEXT,
-                                         timestamp TEXT
-                                       );"""
-            create_table(conn, sql_create_procs_table)
-            create_table(conn, sql_create_jobs_table)
-        return func(*args, **kwargs)
-
-    return wrapper_sqlite_db
-
-
-@sqlite_db
-def sqlite_get_procs():
-    conn = create_connection(db_name)
-    cur = conn.cursor()
-    sql_str = "SELECT * FROM processes"
-    cur.execute(sql_str)
-    return cur.fetchall()
-
-
-@sqlite_db
-def sqlite_get_proc(proc_id):
-    conn = create_connection(db_name)
-    cur = conn.cursor()
-    sql_str = """SELECT * FROM processes
-                 WHERE id = \"{}\"""".format(
-        proc_id
-    )
-    cur.execute(sql_str)
-    res = cur.fetchall()
-    num_matches = len(res)
-    if num_matches == 1:
-        res = res[0]
-    else:
-        assert (
-            num_matches == 0,
-            "Found more than one match for {}. This should never happen.".format(
-                proc_id
-            ),
-        )
-    return res
-
-
-@sqlite_db
-def sqlite_deploy_proc(proc_spec):
-    proc_desc = proc_spec["processDescription"]
-    proc_desc2 = proc_desc["process"]
-    conn = create_connection(db_name)
-    cur = conn.cursor()
-    sql_str = """INSERT INTO processes(id, title, abstract, keywords, 
-                                       owsContextURL, processVersion, 
-                                       jobControlOptions, outputTransmission,
-                                       immediateDeployment, executionUnit)
-                 VALUES(\"{}\", \"{}\", \"{}\", \"{}\", \"{}\", \"{}\", 
-                        \"{}\", \"{}\", \"{}\", \"{}\");""".format(
-        proc_desc2["id"],
-        proc_desc2["title"],
-        proc_desc2["abstract"],
-        ",".join(proc_desc2["keywords"]),
-        proc_desc2["owsContext"]["offering"]["content"]["href"],
-        proc_desc["processVersion"],
-        ",".join(proc_desc["jobControlOptions"]),
-        ",".join(proc_desc["outputTransmission"]),
-        int(proc_spec["immediateDeployment"]),
-        ",".join([d["href"] for d in proc_spec["executionUnit"]]),
-    )
-    cur.execute(sql_str)
-    conn.commit()
-    return sqlite_get_proc(proc_desc2["id"])
-
-
-@sqlite_db
-def sqlite_undeploy_proc(proc_id):
-    proc_desc = sqlite_get_proc(proc_id)
-    if proc_desc:
-        conn = create_connection(db_name)
+    @sqlite_db
+    def sqlite_get_procs(self):
+        conn = self._create_connection(self._db_name)
         cur = conn.cursor()
-        sql_str = """DELETE FROM processes
+        sql_str = "SELECT * FROM processes"
+        cur.execute(sql_str)
+        return cur.fetchall()
+
+    @sqlite_db
+    def sqlite_get_proc(self, proc_id):
+        conn = self._create_connection(self._db_name)
+        cur = conn.cursor()
+        sql_str = """SELECT * FROM processes
                      WHERE id = \"{}\"""".format(
             proc_id
         )
         cur.execute(sql_str)
+        res = cur.fetchall()
+        num_matches = len(res)
+        if num_matches == 1:
+            res = res[0]
+        else:
+            assert (
+                num_matches == 0,
+                "Found more than one match for {}. This should never happen.".format(
+                    proc_id
+                ),
+            )
+        return res
+
+    @sqlite_db
+    def sqlite_deploy_proc(self, proc_spec):
+        proc_desc = proc_spec["processDescription"]
+        proc_desc2 = proc_desc["process"]
+        conn = self._create_connection(self._db_name)
+        cur = conn.cursor()
+        sql_str = """INSERT INTO processes(id, title, abstract, keywords, 
+                                           owsContextURL, processVersion, 
+                                           jobControlOptions,
+                                           outputTransmission,
+                                           immediateDeployment, executionUnit)
+                     VALUES(\"{}\", \"{}\", \"{}\", \"{}\", \"{}\", \"{}\", 
+                            \"{}\", \"{}\", \"{}\", \"{}\");""".format(
+            proc_desc2["id"],
+            proc_desc2["title"],
+            proc_desc2["abstract"],
+            ",".join(proc_desc2["keywords"]),
+            proc_desc2["owsContext"]["offering"]["content"]["href"],
+            proc_desc["processVersion"],
+            ",".join(proc_desc["jobControlOptions"]),
+            ",".join(proc_desc["outputTransmission"]),
+            int(proc_spec["immediateDeployment"]),
+            ",".join([d["href"] for d in proc_spec["executionUnit"]]),
+        )
+        cur.execute(sql_str)
         conn.commit()
-    return proc_desc
+        return self.sqlite_get_proc(proc_desc2["id"])
+
+    @sqlite_db
+    def sqlite_undeploy_proc(self, proc_id):
+        proc_desc = self.sqlite_get_proc(proc_id)
+        if proc_desc:
+            conn = self._create_connection(self._db_name)
+            cur = conn.cursor()
+            sql_str = """DELETE FROM processes
+                         WHERE id = \"{}\"""".format(
+                proc_id
+            )
+            cur.execute(sql_str)
+            conn.commit()
+        return proc_desc
+
+    @sqlite_db
+    def sqlite_get_jobs(self, proc_id=None):
+        conn = self._create_connection(self._db_name)
+        cur = conn.cursor()
+        sql_str = "SELECT * FROM jobs"
+        if proc_id is not None:
+            sql_str += """ WHERE procID = \"{}\"""".format(proc_id)
+        cur.execute(sql_str)
+        job_list = cur.fetchall()
+        col_headers = self._sqlite_get_headers(cur, "jobs")
+        job_dicts = [dict(zip(col_headers, job)) for job in job_list]
+        return job_dicts
 
 
-def sqlite_get_headers(cur, tname):
-    sql_str = 'SELECT name FROM PRAGMA_TABLE_INFO("{}");'.format(tname)
-    cur.execute(sql_str)
-    col_headers = [t[0] for t in cur.fetchall()]
-    return col_headers
+    @sqlite_db
+    def sqlite_get_job(self, job_id):
+        conn = self._create_connection(self._db_name)
+        cur = conn.cursor()
+        sql_str = """SELECT * FROM jobs
+                     WHERE jobID = \"{}\"""".format(
+            job_id
+        )
+        job_matches = cur.execute(sql_str).fetchall()
+        num_matches = len(job_matches)
+        if num_matches == 0:
+            job_dict = {}
+        elif num_matches == 1:
+            job = job_matches[0]
+            col_headers = self._sqlite_get_headers(cur, "jobs")
+            job_dict = {}
+            for i, col in enumerate(col_headers):
+                # deserialize JSON data fields
+                if col in ("inputs", "backend_info", "metrics"):
+                    job_dict[col] = json.loads(job[i])
+                else:
+                    job_dict[col] = job[i]
+        else:
+            # This should never happen.
+            raise ValueError("Found more than one match for job ID {}".format(job_id))
+        return job_dict
 
+    @sqlite_db
+    def sqlite_exec_job(self, proc_id, job_id, job_spec, backend_info):
+        conn = self._create_connection(self._db_name)
+        cur = conn.cursor()
+        cur.execute(
+            """INSERT INTO jobs(jobID, procID, inputs, backend_info, metrics, status, timestamp)
+                    VALUES(?, ?, ?, ?, ?, ?, ?)""",
+            [
+                job_id,
+                proc_id,
+                json.dumps(job_spec),
+                json.dumps(backend_info),
+                "{}",
+                "accepted",
+                datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            ],
+        )
+        conn.commit()
+        return self.sqlite_get_job(job_id)
 
-@sqlite_db
-def sqlite_get_jobs(proc_id=None):
-    conn = create_connection(db_name)
-    cur = conn.cursor()
-    sql_str = "SELECT * FROM jobs"
-    if proc_id is not None:
-        sql_str += """ WHERE procID = \"{}\"""".format(proc_id)
-    cur.execute(sql_str)
-    job_list = cur.fetchall()
-    col_headers = sqlite_get_headers(cur, "jobs")
-    job_dicts = [dict(zip(col_headers, job)) for job in job_list]
-    return job_dicts
-
-
-@sqlite_db
-def sqlite_get_job(job_id):
-    conn = create_connection(db_name)
-    cur = conn.cursor()
-    sql_str = """SELECT * FROM jobs
-                 WHERE jobID = \"{}\"""".format(
-        job_id
-    )
-    job_matches = cur.execute(sql_str).fetchall()
-    num_matches = len(job_matches)
-    if num_matches == 0:
-        job_dict = {}
-    elif num_matches == 1:
-        job = job_matches[0]
-        col_headers = sqlite_get_headers(cur, "jobs")
-        job_dict = {}
-        for i, col in enumerate(col_headers):
-            # deserialize JSON data fields
-            if col in ("inputs", "backend_info", "metrics"):
-                job_dict[col] = json.loads(job[i])
-            else:
-                job_dict[col] = job[i]
-    else:
-        # This should never happen.
-        raise ValueError("Found more than one match for job ID {}".format(job_id))
-    return job_dict
-
-
-@sqlite_db
-def sqlite_exec_job(proc_id, job_id, job_spec, backend_info):
-    conn = create_connection(db_name)
-    cur = conn.cursor()
-    cur.execute(
-        """INSERT INTO jobs(jobID, procID, inputs, backend_info, metrics, status, timestamp)
-                VALUES(?, ?, ?, ?, ?, ?, ?)""",
-        [
-            job_id,
-            proc_id,
-            json.dumps(job_spec),
-            json.dumps(backend_info),
-            "{}",
-            "accepted",
+    @sqlite_db
+    def sqlite_update_job_status(self, job_id, status, metrics):
+        conn = self._create_connection(self._db_name)
+        cur = conn.cursor()
+        sql_str = """UPDATE jobs
+                     SET status = \"{}\",
+                         metrics = \'{}\',
+                         timestamp = \"{}\"
+                     WHERE jobID = \"{}\"""".format(
+            status,
+            json.dumps(metrics),
             datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-        ],
-    )
-    conn.commit()
-    return sqlite_get_job(job_id)
+            job_id,
+        )
+        cur.execute(sql_str)
+        conn.commit()
+        return self.sqlite_get_job(job_id)
 
-
-@sqlite_db
-def sqlite_update_job_status(job_id, status, metrics):
-    conn = create_connection(db_name)
-    cur = conn.cursor()
-    sql_str = """UPDATE jobs
-                 SET status = \"{}\",
-                     metrics = \'{}\',
-                     timestamp = \"{}\"
-                 WHERE jobID = \"{}\"""".format(
-        status,
-        json.dumps(metrics),
-        datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-        job_id,
-    )
-    cur.execute(sql_str)
-    conn.commit()
-    return sqlite_get_job(job_id)
-
-
-@sqlite_db
-def sqlite_dismiss_job(job_id):
-    job_dict = sqlite_get_job(job_id)
-    if job_dict:
-        resp = sqlite_update_job_status(job_id, "dismissed", {})
-    else:
-        resp = {}
-    return resp
+    @sqlite_db
+    def sqlite_dismiss_job(self, job_id):
+        job_dict = self.sqlite_get_job(job_id)
+        if job_dict:
+            resp = self.sqlite_update_job_status(job_id, "dismissed", {})
+        else:
+            resp = {}
+        return resp

--- a/flask_ades_wpst/sqlite_connector.py
+++ b/flask_ades_wpst/sqlite_connector.py
@@ -66,6 +66,7 @@ class SQLiteConnector():
                                             );"""
                 sql_create_jobs_table = """CREATE TABLE IF NOT EXISTS jobs (
                                              jobID TEXT PRIMARY KEY,
+                                             jobOwner TEXT,
                                              procID TEXT,
                                              inputs DATA,
                                              backend_info DATA,
@@ -163,7 +164,6 @@ class SQLiteConnector():
         job_dicts = [dict(zip(col_headers, job)) for job in job_list]
         return job_dicts
 
-
     @sqlite_db
     def sqlite_get_job(self, job_id):
         conn = self._create_connection(self._db_name)
@@ -192,14 +192,16 @@ class SQLiteConnector():
         return job_dict
 
     @sqlite_db
-    def sqlite_exec_job(self, proc_id, job_id, job_spec, backend_info):
+    def sqlite_exec_job(self, proc_id, job_id, job_spec, job_owner,
+                        backend_info):
         conn = self._create_connection(self._db_name)
         cur = conn.cursor()
         cur.execute(
-            """INSERT INTO jobs(jobID, procID, inputs, backend_info, metrics, status, timestamp)
-                    VALUES(?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT INTO jobs(jobID, jobOwner, procID, inputs, backend_info, metrics, status, timestamp)
+                    VALUES(?, ?, ?, ?, ?, ?, ?, ?)""",
             [
                 job_id,
+                job_owner,
                 proc_id,
                 json.dumps(job_spec),
                 json.dumps(backend_info),


### PR DESCRIPTION
This is a large update that includes a change to the SQLite job table schema and several API updates.  We should confirm that this works in ADES-K8S before merging @pymonger .  
1. In ADES-PBS:  match the metrics schema from https://docs.google.com/presentation/d/1bTMKPRAeioxsKv7okcvWYjIbXoynmB8T8H2bL3vzYLU/edit#slide=id.g14215199578_0_2205.
2. Added new command line options for Flask app: `[-p --port port-number]`, `[-d --debug]`, and `[-n --name <ades-name>]`
3. Updated jobs table schema:  replaced `timestamp` with `timeCreated` and `timeUpdated` in order to support reporting of `time_queued` in `getJobStatus`.
4. Isolate each ADES instance in its own subdirectory (directory name matches the ADES ID).  This, combined with the new `-p` and `-n` options mentioned above supports running multiple ADES instances on the same host.
5. In `sql_connector.py`, changed the implementation to be a Class `SQLiteConnector`.
6. The `executeJob` request can now accept a `user=<username>` keyword to specify the owner of the job.  That username is included as part of the `getJobStatus` response.  If it is omitted, the job owner defaults to `anonymous`.
7. Added new fields for each endpoint listed in the `getLandingPage` response:  `parameters` ,`payload`, `example`.
8. Miscellaneous comments and code reorganization in `flask_wpst.py`.