### PR TITLE
maap-hec-aws-110: Implement getJobResult endpoint

### DIFF
--- a/flask_ades_wpst/ades_k8s.py
+++ b/flask_ades_wpst/ades_k8s.py
@@ -547,14 +547,4 @@ class ADES_K8s(ADES_ABC):
         return job_spec
 
     def get_job_results(self, job_spec):
-        res = {
-            "links": [
-                {
-                    "href": "https://mypath",
-                    "rel": "result",
-                    "type": "application/json",
-                    "title": "mytitle",
-                }
-            ]
-        }
-        return {**job_spec, **res}
+        return {}

--- a/flask_ades_wpst/ades_pbs.py
+++ b/flask_ades_wpst/ades_pbs.py
@@ -241,8 +241,4 @@ python -m flask_ades_wpst.get_pbs_metrics -l {} -m {} -e {}
         return job_spec
 
     def get_job_results(self, job_spec):
-        res =  {"links": [{"href": "https://mypath",
-                           "rel": "result",
-                           "type": "application/json",
-                           "title": "mytitle"}]}
-        return {**job_spec, **res}
+        return {}


### PR DESCRIPTION
In the ADES_Base implementation I appended `<job_id>/output` to the `stage_out.s3_url` workflow input and implemented the getJobResult endpoint.  The getJobResult implementation is in the ADES_Base layer, so should apply to all ADES platforms.  